### PR TITLE
Add gem path to PATH to allow heroku to find bundler

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ export GEM_HOME="$BUILD_DIR/gems"
 export GEM_PATH=$GEM_HOME
 mkdir -p $GEM_HOME
 LANG="en_US.UTF-8" gem install bundler sass
-export PATH="/app/bin:$PATH"
+export PATH="/app/bin:$PATH:$GEM_PATH/bin"
 
 #node setup
 


### PR DESCRIPTION
Heroku push was failing to find bundle when it was time for the "bundle install" step
