### PR TITLE
Npm install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -184,7 +184,7 @@ export CPPPATH="$INCLUDE_PATH"
 
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
-run_npm "install --production"
+run_npm "install"
 run_npm "rebuild"
 echo "Dependencies installed" | indent
 


### PR DESCRIPTION
Opened this for discussion. It ties back to the package.json configuration within a lineman project.
1. lineman is not a runtime/production dep because one does not `require` lineman from the app
2. lineman fits better as a dev dep so it should be listed in package.json under `devDependencies`
3. to install dev deps, one runs `npm install --dev` or alternatively `npm install`
