### PR TITLE
Cache node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .anvil
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+## Testing buildpack changes using Anvil
+
+[Anvil](https://github.com/ddollar/anvil) is a generic build server for Heroku.
+
+```
+gem install anvil-cli
+```
+
+The [heroku-anvil CLI plugin](https://github.com/ddollar/heroku-anvil) is a wrapper for anvil.
+
+```
+heroku plugins:install https://github.com/ddollar/heroku-anvil
+```
+
+The [ddollar/test buildpack](https://github.com/ddollar/buildpack-test) is for testing things: it runs `bin/test` on your app.
+
+```
+heroku build -b ddollar/test # -b can also point to a local directory
+```
+
+## Compiling new versions of node and npm using Vulcan
+
+Install [vulcan](https://github.com/heroku/vulcan) and create your own build server. Use any
+app name you want and vulcan will remember it in a `~/.vulcan` config file.
+
+```
+gem install vulcan
+vulcan create builder-bob
+```
+
+Store your S3 credentials in `~/.aws/`
+
+```
+mkdir -p ~/.aws
+echo 'YOUR_AWS_KEY' > ~/.aws/key-nodejs.access
+echo 'YOUR_AWS_SECRET' > ~/.aws/key-nodejs.secret
+```
+
+Add a credentials exporter to your `.bash_profile` or `.bashrc`
+
+```
+setup_nodejs_env () {
+  export AWS_ID=$(cat ~/.aws/key-nodejs.access)
+  export AWS_SECRET=$(cat ~/.aws/key-nodejs.secret)
+  export S3_BUCKET="heroku-buildpack-nodejs"
+}
+```
+
+Build:
+
+```
+setup_nodejs_env
+support/package_nodejs <node-version>
+support/package_npm <npm-version>
+```
+
+## Publishing buildpack updates
+
+```
+heroku plugins:install https://github.com/heroku/heroku-buildpacks
+
+cd heroku-buildpack-nodejs
+git checkout master
+heroku buildpacks:publish heroku/nodejs
+```
+
+- Email [dos@heroku.com](mailto:dos@heroku.com) if changes are significant.
+- Add a [changelog item](https://devcenter.heroku.com/admin/changelog_items/new).
+- Update [Node Devcenter articles](https://devcenter.heroku.com/admin/articles/owned) as necessary.
+
+## Keeping up with the Nodeses
+
+- Run `npm info npm version` to find out the latest available version of npm.
+- Follow [@nodejs](https://twitter.com/nodejs) and [@npmjs](https://twitter.com/npmjs) on Twitter.

--- a/bin/compile
+++ b/bin/compile
@@ -107,6 +107,14 @@ function package_download() {
   curl $package -s -o - | tar xzf - -C $location
 }
 
+function cat_npm_debug_log() {
+  if [ -f $BUILD_DIR/npm-debug.log ]; then
+    cat $BUILD_DIR/npm-debug.log
+  fi
+}
+
+trap cat_npm_debug_log EXIT
+
 bootstrap_node=$(mktmpdir bootstrap_node)
 package_download "nodejs" "0.4.7" $bootstrap_node
 
@@ -116,7 +124,7 @@ declare -A engine_defaults
 declare -A engine_requests
 
 engine_defaults["node"]="0.10.x"
-engine_defaults["npm"]="1.2.x"
+engine_defaults["npm"]="1.3.x"
 
 engine_versions["node"]=$(manifest_versions "nodejs")
 engine_requests["node"]=$(package_engine_version "node")
@@ -130,7 +138,7 @@ echo "-----> Resolving engine versions"
 if [ "${engine_requests["node"]}" == "" ]; then
   echo
   echo "WARNING: No version of Node.js specified in package.json, see:" | indent
-  echo "https://devcenter.heroku.com/articles/nodejs-versions" | indent
+  echo "https://devcenter.heroku.com/articles/nodejs-support#versions" | indent
   echo
 fi
 
@@ -169,8 +177,18 @@ cp "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node"
 # setting up paths for building
 PATH="$VENDORED_SCONS:$VENDORED_NODE/bin:$PATH"
 INCLUDE_PATH="$VENDORED_NODE/include"
-export CPATH="$INCLUDE_PATH"
-export CPPPATH="$INCLUDE_PATH"
+export CPATH="$INCLUDE_PATH:$CPATH"
+export CPPPATH="$INCLUDE_PATH:$CPPPATH"
+
+# restore node_modules cache
+if [ -d $CACHE_STORE_DIR ]; then
+  echo "-----> Restoring node_modules cache"
+  if [ -d $CACHE_TARGET_DIR ]; then
+    cp -r $CACHE_STORE_DIR/* $CACHE_TARGET_DIR/
+  else
+    cp -r $CACHE_STORE_DIR $CACHE_TARGET_DIR
+  fi
+fi
 
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
@@ -183,6 +201,15 @@ if [ ! -f $BUILD_DIR/node_modules/.bin/lineman ]; then
 fi
 echo "Dependencies installed" | indent
 
+# cache node_modules
+if [ -d $CACHE_TARGET_DIR ]; then
+  echo "-----> Caching node_modules"
+  rm -rf $CACHE_STORE_DIR
+  mkdir -p $(dirname $CACHE_STORE_DIR)
+  cp -r $CACHE_TARGET_DIR $CACHE_STORE_DIR
+fi
+
+# build .profile.d/nodejs.sh
 echo "-----> Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\"\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\"" > $BUILD_DIR/.profile.d/nodejs.sh

--- a/bin/test
+++ b/bin/test
@@ -31,7 +31,7 @@ testPackageJsonWithoutVersion() {
   compile "package-json-noversion"
   assertCaptured "WARNING: No version of Node.js specified"
   assertCaptured "Using Node.js version: 0.10"
-  assertCaptured "Using npm version: 1.2"
+  assertCaptured "Using npm version: 1.3"
   assertCapturedSuccess
 }
 
@@ -40,18 +40,17 @@ testPackageJsonWithInvalidVersion() {
   assertCapturedError 1 "Requested engine npm version 1.1.5 does not"
 }
 
-testNothingCached() {
-  cache=$(mktmpdir)
-  compile "package-json-version" $cache
-  assertCapturedSuccess
-  assertEquals "0" "$(ls -1 $cache | wc -l)"
-}
-
 testProfileCreated() {
   compile "package-json-version"
   assertCaptured "Building runtime environment"
   assertFile "export PATH=\"\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\"" ".profile.d/nodejs.sh"
   assertCapturedSuccess
+}
+
+testNodeModulesCached() {
+  cache=$(mktmpdir)
+  compile "node-modules-caching" $cache
+  assertEquals "1" "$(ls -1 $cache/node_modules/0.10.15/1.3.5 | wc -l)"
 }
 
 ## utils ########################################
@@ -78,7 +77,7 @@ COMPILE_DIR=""
 compile() {
   COMPILE_DIR=$(mktmpdir)
   cp -r ${BASE}/test/$1/* ${COMPILE_DIR}/
-  capture ${BASE}/bin/compile ${COMPILE_DIR} $2
+  capture ${BASE}/bin/compile ${COMPILE_DIR} ${2:-$(mktmpdir)}
 }
 
 assertFile() {

--- a/test/node-modules-caching/package.json
+++ b/test/node-modules-caching/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "myapp",
+  "version": "0.0.1",
+
+  "engines": {
+    "node": "0.10.15",
+    "npm": "1.3.5"
+  },
+
+  "dependencies": {
+    "express": "latest"
+  }
+}


### PR DESCRIPTION
This merges in the changes from https://github.com/ddollar/heroku-buildpack-nodejs, which caches the node_modules between deploys. I didn't time it, but it makes deploys SIGNIFICANTLY faster.
