### PR TITLE
Run htpasswd only if $USERNAME & $PASSWORD are set

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -283,7 +283,9 @@ fi
 
 cat >>boot.sh <<EOF
 export LD_LIBRARY_PATH=/app/apache/lib/
-/app/apache/bin/htpasswd -bc /app/.passwords \$USERNAME \$PASSWORD
+if [ -n "$USERNAME" ] && [ -n "$PASSWORD" ]; then
+  /app/apache/bin/htpasswd -bc /app/.passwords \$USERNAME \$PASSWORD
+fi
 sed -i 's/Listen 80/Listen '\$PORT'/' /app/apache/conf/httpd.conf
 echo "Launching apache"
 exec /app/apache/bin/httpd -X


### PR DESCRIPTION
If you don't set $USERNAME and $PASSWORD you'll see this output when deploying using the lineman build pack:

```
2014-01-06T18:27:43.719560+00:00 app[web.1]:
2014-01-06T18:27:43.719560+00:00 app[web.1]:    htpasswd -n[mdps] username
2014-01-06T18:27:43.719560+00:00 app[web.1]: Usage:
2014-01-06T18:27:43.719560+00:00 app[web.1]:    htpasswd [-cmdpsD] passwordfile username
2014-01-06T18:27:43.719560+00:00 app[web.1]:    htpasswd -b[cmdpsD] passwordfile username password
2014-01-06T18:27:43.719560+00:00 app[web.1]:    htpasswd -nb[mdps] username password
2014-01-06T18:27:43.719560+00:00 app[web.1]:  -c  Create a new file.
2014-01-06T18:27:43.719560+00:00 app[web.1]:  -n  Don't update file; display results on stdout.
2014-01-06T18:27:43.719560+00:00 app[web.1]:  -m  Force MD5 encryption of the password (default).
2014-01-06T18:27:43.719560+00:00 app[web.1]:  -d  Force CRYPT encryption of the password.
2014-01-06T18:27:43.719741+00:00 app[web.1]:  -p  Do not encrypt the password (plaintext).
2014-01-06T18:27:43.719741+00:00 app[web.1]:  -s  Force SHA encryption of the password.
2014-01-06T18:27:43.719741+00:00 app[web.1]:  -b  Use the password from the command line rather than prompting for it.
2014-01-06T18:27:43.719741+00:00 app[web.1]:  -D  Delete the specified user.
2014-01-06T18:27:43.719741+00:00 app[web.1]: On other systems than Windows, NetWare and TPF the '-p' flag will probably not work.
2014-01-06T18:27:43.719741+00:00 app[web.1]: The SHA algorithm does not use a salt and is less secure than the MD5 algorithm.
```

This is because the `boot.sh` unconditionally runs `/app/apache/bin/htpasswd`:

```
cat >>boot.sh <<EOF
export LD_LIBRARY_PATH=/app/apache/lib/
/app/apache/bin/htpasswd -bc /app/.passwords \$USERNAME \$PASSWORD
sed -i 's/Listen 80/Listen '\$PORT'/' /app/apache/conf/httpd.conf
echo "Launching apache"
exec /app/apache/bin/httpd -X
EOF
```

This pull request checks to see that both $USERNAME and $PASSWORD are set to non blank values before running htpasswd.
